### PR TITLE
コメント画面／ユーザー名のリンク修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -48,13 +48,6 @@ class PrototypesController < ApplicationController
     prototype.destroy
     redirect_to root_path
   end
-  
-
-  def destroy
-    prototype = Prototype.find(params[:id])
-    prototype.destroy
-    redirect_to root_path
-  end
 
   private
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,8 +1,8 @@
 class PrototypesController < ApplicationController
   before_action :set_prototype, only: :show
-  before_action :authenticate_user!, only: [:edit, :update,:destroy]
+  before_action :authenticate_user!, only: [:edit, :update, :destroy]
   before_action :ensure_correct_user, only: :destroy
-  
+
   def index
     @prototypes = Prototype.all
   end
@@ -21,17 +21,16 @@ class PrototypesController < ApplicationController
   end
 
   def edit
-    @prototype = Prototype.find(params[:id])  
-    unless current_user == @prototype.user
-      redirect_to root_path
-    end
+    @prototype = Prototype.find(params[:id])
+    return if current_user == @prototype.user
 
-  end  
-  
+    redirect_to root_path
+  end
+
   def update
     @prototype = Prototype.find(params[:id])
     if @prototype.update(prototype_params)
-       redirect_to  prototype_path(@prototype)    
+      redirect_to prototype_path(@prototype)
     else
       render :edit
     end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -40,6 +40,7 @@ class PrototypesController < ApplicationController
   def show
     @comment = Comment.new
     @comments = @prototype.comments.includes(:user)
+    @prototype = Prototype.find(params[:id])
   end
 
   def destroy

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -45,7 +45,7 @@
           <% @comments.each do |comment|%>
             <li class="comments_list">
               <%= comment.comment%>
-              <%= link_to "(#{comment.user.username})", root_path, class: :comment_user %>
+              <%= link_to "（#{comment.user.username}）", user_path(comment.user), class: :comment_user %>
             </li>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
           <%end%>


### PR DESCRIPTION
# What
コメント画面に表示されているユーザー名のリンク修正

# Why
ユーザー詳細機能へ遷移するリンクの設定漏れがあったため

コメントを投稿したユーザー名をクリックすると、該当ユーザーの詳細が名が表示されるよう、リンクを修正致しました。
ご確認をよろしくお願い致します。

※ユーザー名のリンク修正の動画は、以下の通りです。
　https://gyazo.com/b510b3b8e2224f58159c8d57871ac0b4

・・・・・

リンクの設定にて、プロトタイプのコントローラー（prototypes_controller.rb）を編集した際に、「def destroy」が二重に記述されている箇所を発見しました。
全く同じ内容だったため、重複している箇所を削除し、削除の動作確認をしました。
以下の動画をご確認を頂きたく、お願い致します。

※削除機能の動作確認の動画は、以下の通りです。
　https://gyazo.com/eb48e0138babcd23a12c259b762486c5

以上です。